### PR TITLE
fix: agent detail 500 on Vercel — force-dynamic

### DIFF
--- a/app/[locale]/agents/[slug]/page.tsx
+++ b/app/[locale]/agents/[slug]/page.tsx
@@ -40,9 +40,7 @@ const AGENTS: Record<string, {
 
 const VALID_SLUGS = Object.keys(AGENTS);
 
-export async function generateStaticParams() {
-  return VALID_SLUGS.map((slug) => ({ slug }));
-}
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata({
   params,


### PR DESCRIPTION
Replace generateStaticParams with force-dynamic. generateStaticParams causes DYNAMIC_SERVER_USAGE on Vercel because getTranslations uses request-scoped APIs.