### PR TITLE
feat: Page À propos avec photo Erwan et story (#86)

### DIFF
--- a/app/[locale]/a-propos/page.tsx
+++ b/app/[locale]/a-propos/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowRight, Zap, Globe, Brain, GitBranch } from "lucide-react";
+import { ArrowRight, Zap, Globe, Brain, GitBranch, Linkedin } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -64,12 +64,29 @@ export default async function AProposPage() {
           <div className="space-y-4">
             <div className="relative overflow-hidden rounded-2xl border border-white/10">
               <Image
-                src="/images/about.png"
+                src="/images/founder-erwan.jpg"
                 alt={t("imageAlt")}
                 width={600}
                 height={400}
-                className="w-full object-cover opacity-90"
+                className="w-full object-cover"
               />
+              <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-gray-950/90 to-transparent p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-sm font-semibold text-white">Erwan Poiraud</div>
+                    <div className="text-xs text-gray-400">{t("founderRole" as Key)}</div>
+                  </div>
+                  <a
+                    href="https://www.linkedin.com/in/erwanpoiraud/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/10 text-gray-300 transition-colors hover:bg-emerald-500/20 hover:text-emerald-400"
+                    aria-label="LinkedIn"
+                  >
+                    <Linkedin className="h-4 w-4" />
+                  </a>
+                </div>
+              </div>
             </div>
             <div className="grid grid-cols-2 gap-4">
               {stats.map((s) => (

--- a/messages/en.json
+++ b/messages/en.json
@@ -380,7 +380,8 @@
     "ctaTitle": "Shall we work together?",
     "ctaSubtitle": "Send us your challenge. We respond with a concrete approach.",
     "ctaButton": "Start the conversation",
-    "imageAlt": "Agentic AI connection network"
+    "imageAlt": "Erwan Poiraud, founder of TheNoCodeGuy",
+    "founderRole": "Founder & AI Consultant"
   },
   "contact": {
     "metaTitle": "Contact — Let's talk about your project",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -380,7 +380,8 @@
     "ctaTitle": "On travaille ensemble ?",
     "ctaSubtitle": "Envoyez-nous votre challenge. On vous répond avec une approche concrète.",
     "ctaButton": "Démarrer la conversation",
-    "imageAlt": "Réseau de connexions IA agentique"
+    "imageAlt": "Erwan Poiraud, fondateur de TheNoCodeGuy",
+    "founderRole": "Fondateur & Consultant IA"
   },
   "contact": {
     "metaTitle": "Contact — Parlons de votre projet",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -380,7 +380,8 @@
     "ctaTitle": "我们一起合作？",
     "ctaSubtitle": "发送您的挑战给我们。我们将提供具体的解决方案。",
     "ctaButton": "开始对话",
-    "imageAlt": "AI 智能体连接网络"
+    "imageAlt": "Erwan Poiraud，TheNoCodeGuy 创始人",
+    "founderRole": "创始人兼 AI 顾问"
   },
   "contact": {
     "metaTitle": "联系我们 — 谈谈您的项目",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -380,7 +380,8 @@
     "ctaTitle": "要一起合作嗎？",
     "ctaSubtitle": "告訴我們您的挑戰。我們將提供具體的解決方案。",
     "ctaButton": "開始對話",
-    "imageAlt": "AI 代理連接網路"
+    "imageAlt": "Erwan Poiraud，TheNoCodeGuy 創辦人",
+    "founderRole": "創辦人暨 AI 顧問"
   },
   "contact": {
     "metaTitle": "聯絡我們 — 談談您的專案",


### PR DESCRIPTION
Closes PBI #86

## Changes
- Replaced generic about.png with real founder photo (founder-erwan.jpg)
- Added name overlay: "Erwan Poiraud" + localized role on the photo
- Added LinkedIn button linking to linkedin.com/in/erwanpoiraud/
- Updated image alt text in all 4 locales
- Added founderRole i18n key in all 4 locales

## AC Verification
- ✅ Page /a-propos with Erwan photo (real, not AI)
- ✅ Short bio + journey (already existed, kept intact)
- ✅ LinkedIn link on photo overlay
- ✅ 4 locales translated
- ✅ Photo real and optimized (founder-erwan.jpg)