### PR TITLE
feat: ATOM-2 Header — nav, CTA, light/dark toggle (#103)

### DIFF
--- a/components/molecules/NavLink.tsx
+++ b/components/molecules/NavLink.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+interface NavLinkProps {
+  href: string;
+  label: string;
+  active?: boolean;
+  onClick?: () => void;
+  className?: string;
+}
+
+export default function NavLink({ href, label, active, onClick, className }: NavLinkProps) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      className={cn(
+        "text-sm font-medium transition-colors",
+        active
+          ? "text-primary"
+          : "text-muted-foreground hover:text-foreground",
+        className
+      )}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/components/organisms/Header.tsx
+++ b/components/organisms/Header.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X, Zap, Moon, Sun } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import NavLink from "@/components/molecules/NavLink";
+import { cn } from "@/lib/utils";
+
+export default function Header() {
+  const t = useTranslations("nav");
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [dark, setDark] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+
+  // Theme toggle
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const isDark = stored === "dark" || (!stored && prefersDark);
+    setDark(isDark);
+    document.documentElement.classList.toggle("dark", isDark);
+  }, []);
+
+  const toggleTheme = () => {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+  };
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeMenu();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  // Scroll lock
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  // Focus trap
+  useEffect(() => {
+    if (!open || !menuRef.current) return;
+    const focusable = menuRef.current.querySelectorAll<HTMLElement>(
+      'a, button, [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length > 0) focusable[0].focus();
+    const onTab = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || !focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onTab);
+    return () => document.removeEventListener("keydown", onTab);
+  }, [open]);
+
+  // Close on route change
+  useEffect(() => { setOpen(false); }, [pathname]);
+
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+    toggleRef.current?.focus();
+  }, []);
+
+  const links = [
+    { href: "#agents", label: t("agents") },
+    { href: "#how", label: t("howItWorks") },
+    { href: "#pricing", label: t("pricing") },
+    { href: "/contact", label: t("contact") },
+  ];
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
+        {/* Logo */}
+        <Link href="/" className="flex items-center gap-2 text-lg font-bold">
+          <Zap className="h-5 w-5 text-primary" />
+          <span>
+            TheNoCode<span className="text-primary">Guy</span>
+          </span>
+        </Link>
+
+        {/* Desktop nav */}
+        <nav className="hidden items-center gap-6 md:flex">
+          {links.map((l) => (
+            <NavLink key={l.href} href={l.href} label={l.label} />
+          ))}
+          <Button size="sm" asChild>
+            <Link href="/contact">{t("startProject")}</Link>
+          </Button>
+          <button
+            onClick={toggleTheme}
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground"
+            aria-label="Toggle theme"
+          >
+            {dark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+          </button>
+        </nav>
+
+        {/* Mobile: theme toggle + hamburger */}
+        <div className="flex items-center gap-2 md:hidden">
+          <button
+            onClick={toggleTheme}
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground"
+            aria-label="Toggle theme"
+          >
+            {dark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+          </button>
+          <button
+            ref={toggleRef}
+            onClick={() => setOpen(!open)}
+            aria-label={open ? "Close menu" : "Open menu"}
+            aria-expanded={open}
+            aria-controls="mobile-menu"
+            className="text-muted-foreground"
+          >
+            {open ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile overlay */}
+      <div
+        className={cn(
+          "fixed inset-0 top-[57px] z-40 bg-black/40 backdrop-blur-sm transition-opacity duration-300 md:hidden",
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        )}
+        onClick={closeMenu}
+        aria-hidden="true"
+      />
+
+      {/* Mobile drawer */}
+      <div
+        id="mobile-menu"
+        ref={menuRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
+        className={cn(
+          "fixed left-0 right-0 top-[57px] z-50 border-b border-border bg-background px-4 pb-6 pt-2 shadow-lg transition-all duration-300 ease-out md:hidden",
+          open ? "translate-y-0 opacity-100" : "-translate-y-4 pointer-events-none opacity-0"
+        )}
+      >
+        {links.map((l) => (
+          <NavLink
+            key={l.href}
+            href={l.href}
+            label={l.label}
+            onClick={closeMenu}
+            className="block py-3 text-base"
+          />
+        ))}
+        <Button className="mt-3 w-full" asChild>
+          <Link href="/contact" onClick={closeMenu}>{t("startProject")}</Link>
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -23,7 +23,8 @@
     "agents": "Agents",
     "pricing": "Pricing",
     "contact": "Contact",
-    "startProject": "Hire an agent"
+    "startProject": "Hire an agent",
+    "howItWorks": "How it works"
   },
   "footer": {
     "home": "Home",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -23,7 +23,8 @@
     "agents": "Agents",
     "pricing": "Tarifs",
     "contact": "Contact",
-    "startProject": "Engager un agent"
+    "startProject": "Engager un agent",
+    "howItWorks": "Comment ça marche"
   },
   "footer": {
     "home": "Accueil",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -23,7 +23,8 @@
     "agents": "智能代理",
     "pricing": "价格",
     "contact": "联系",
-    "startProject": "聘请代理"
+    "startProject": "聘请代理",
+    "howItWorks": "运作方式"
   },
   "footer": {
     "home": "首页",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -23,7 +23,8 @@
     "agents": "智能代理",
     "pricing": "價格",
     "contact": "聯絡",
-    "startProject": "聘請代理"
+    "startProject": "聘請代理",
+    "howItWorks": "運作方式"
   },
   "footer": {
     "home": "首頁",


### PR DESCRIPTION
Closes PBI #103

## Changes
- `components/organisms/Header.tsx`: Sticky header with nav links, CTA button (shadcn Button), theme toggle (Sun/Moon)
- `components/molecules/NavLink.tsx`: Reusable nav link with active state via semantic tokens
- Theme toggle: localStorage persistence, respects prefers-color-scheme, toggles .dark class
- Mobile: hamburger menu with overlay, slide animation, focus trap, Escape close, scroll lock
- Added `howItWorks` i18n key to all 4 locales
- Uses semantic tokens (bg-background, text-foreground, border-border) — works in both light and dark

## AC Verification
- ✅ Sticky header with navigation
- ✅ CTA button (shadcn/ui Button)
- ✅ Light/dark toggle with persistence
- ✅ Mobile-first responsive
- ✅ Atomic Design: organism (Header) + molecule (NavLink)